### PR TITLE
Fix column matcher duplicate mapping bug

### DIFF
--- a/src/components/ColumnMatcher.tsx
+++ b/src/components/ColumnMatcher.tsx
@@ -18,13 +18,15 @@ function guessMatches(source: string[], dest: string[]): Record<string, string |
     const normalizedDest = normalize(d);
     let match: string | undefined;
 
+    const available = source.filter(s => !used.has(s));
+
     if (normalizedDest === 'accountdescription') {
-      match = source.find(s => normalize(s).includes('description'));
+      match = available.find(s => normalize(s).includes('description'));
     } else if (normalizedDest === 'netchange') {
-      const netChangeMatches = source.filter(s => normalize(s).includes('netchange'));
+      const netChangeMatches = available.filter(s => normalize(s).includes('netchange'));
       match = netChangeMatches.length > 0 ? netChangeMatches[netChangeMatches.length - 1] : undefined;
     } else {
-      match = source.find(s => normalize(s) === normalizedDest);
+      match = available.find(s => normalize(s) === normalizedDest);
     }
 
     if (match) {


### PR DESCRIPTION
## Summary
- prevent `guessMatches` from assigning a source header to multiple destination headers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684b2fd2215883339bb608aabc6a5cea